### PR TITLE
feat: fixed url to edit page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,13 +24,13 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/boldare/boldare-radar/",
+          editUrl: "https://github.com/boldare/boldare-radar/edit/main",
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },
         blog: {
           showReadingTime: true,
-          editUrl: "https://github.com/boldare/boldare-radar/",
+          editUrl: "https://github.com/boldare/boldare-radar/edit/main",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
Changed url from `boldare/boldare-radar` to `boldare/boldare-radar/edit/main`.
Current link to edit wasn't working, so I've changed it to edit on `main` branch.
