### PR TITLE
fix: last update author and date

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,10 +17,12 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Use Node.js 14
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
           cache: "yarn"
       - name: Install dependencies
         id: install-deps


### PR DESCRIPTION
Currently on every page the last update date and last update author are equal to last commit date and last commit author

<img width="308" alt="image" src="https://user-images.githubusercontent.com/26148834/172628888-6a1819e0-0a37-4a71-9570-c87635de8db6.png">

https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951