### PR TITLE
chore: fix lint warnings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 node_modules
 public
 build
+src/radar/visualization.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   env: {
     browser: true,
@@ -23,5 +24,19 @@ module.exports = {
     sourceType: "module",
   },
   plugins: ["react", "@typescript-eslint"],
-  rules: {},
+  rules: {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
 };

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -8,7 +8,7 @@ export function useGoogleAuth({
 }) {
   const [logged, setLogged] = React.useState<boolean>(false);
 
-  function handleCredentialResponse(response: CredentialResponse) {
+  function handleCredentialResponse(_response: CredentialResponse) {
     setLogged(true);
   }
 


### PR DESCRIPTION
1. The `visualization` code is taken from Zalando, so imo it's not worth to fix the warnings inside it. 
2. I've added ignore patterns to skip no-unused-vars warnings, because I feel that it's better to leave eg. in `useGoogleAuth#handleCredentialResponse` the info about arguments, to be aware that we can use them