### PR TITLE
fix: baseUrl changed to /tech-radar/

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ const config = {
   title: "Boldare Radar",
   tagline: "Boldare Radar",
   url: "https://boldare.com",
-  baseUrl: "/",
+  baseUrl: "/tech-radar/",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/icon.png",


### PR DESCRIPTION
Since radar will be available at:
boldare.com with `/tech-radar/` then we should change baseURL. 