### PR TITLE
fix: change url to boldare since redirects often cause issues

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ require("dotenv").config();
 const config = {
   title: "Boldare Radar",
   tagline: "Boldare Radar",
-  url: "https://*",
+  url: "https://boldare.com",
   baseUrl: "/tech-radar/",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
url of app was using asterisk but now its changed to boldare website since Radar is accessed through boldare website