### PR TITLE
feat: swizzled mdxcontent component to introduce empty state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
       },
     ],
     "react/no-unescaped-entities": "off",
+    "react/prop-types": "off",
   },
   settings: {
     react: {

--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import MDXContent from "@theme-original/MDXContent";
+
+export default function MDXContentWrapper(props) {
+  const hasContent = !!props.children.type.metadata.description;
+  return (
+    <>
+      <MDXContent {...props} />
+      {!hasContent && (
+        <span>
+          We’re constantly growing our radar to bring you even more value.{" "}
+          <br />
+          This page content will be published soon. <br />
+          Thank you for understanding.
+        </span>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
swizzled (wrapped) docusaurus component to introduce text that explains
lack of content for doc page in radar

## Screenshot
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/25750513/186911803-bb15873b-c21a-4e4d-a38a-f7f7d70e1108.png">
